### PR TITLE
Pass a BitPat to Lookup

### DIFF
--- a/src/main/scala/tracegen.scala
+++ b/src/main/scala/tracegen.scala
@@ -133,7 +133,7 @@ class TagMan(val logNumTags : Int) extends Module {
   val inUse = List.fill(numTags)(Reg(init = Bool(false)))
 
   // Mapping from each tag to its 'inUse' bit
-  val inUseMap = (0 to numTags-1).map(i => UInt(i, logNumTags)).zip(inUse)
+  val inUseMap = (0 to numTags-1).map(i => BitPat(UInt(i))).zip(inUse)
 
   // Next tag to offer
   val nextTag = Reg(init = UInt(0, logNumTags))


### PR DESCRIPTION
This is the only supported type of Lookup in Chisel 3.